### PR TITLE
Migrate Syllabus to website

### DIFF
--- a/docs/syllabus.md
+++ b/docs/syllabus.md
@@ -2,5 +2,95 @@
 sidebar_position: 0
 ---
 
-# Syllabus
-Todo
+# ICSSC Projects Fellowship Syllabus
+Welcome to the **ICS Student Council Fellowship**!
+
+The goal of this course is to teach you fundamental software development and web development skills that aren’t normally taught in the classroom. By the end of the quarter, you will have the skillset necessary to create your own React websites and will have the opportunity to contribute to one our ICSSC Projects such as [AntAlmanac](https://antalmanac.com), [PeterPortal](http://peterportal.org), or [Zotistics](http://zotistics.com)!
+
+This is an **asynchronous** course with prerecorded videos, weekly assignments, and virtual Discord Office Hours. You should be able to commit 2-3 hours per week for this Fellowship.
+
+*Disclaimer: This course is **not** for credit and is **not** affiliated with UCI.*
+
+💡 Want to join us in Spring 2022? Fill out this [interest form](https://forms.gle/St2ABHuisbaJZXSp9).
+
+## <u>Instructors</u>
+
+| Name | Pronouns | Email | GitHub |
+| :--- | :--- | :--- | :--- |
+| Chase Carnaroli | He, Him, His | ccarnaro@uci.edu | ChaseC99 |
+| Raman Gupta | He, Him, His | rxgupta@uci.edu | ramanxg |
+
+## <u>Course Timeline</u>
+
+*This is our tentative course timeline and is subject to change.* 
+
+| Week | Topics | Content | Unit Page |
+| :--- | :--- | :--- | :--- |
+| 1 | Fellowship Application, GitHub | Apply to the Fellowship and get your GitHub setup. | [Unit 1](https://fellowship.icssc.club/docs/unit1) |
+| 2 | Terminal | The basics of the terminal. | [Unit 2](https://fellowship.icssc.club/docs/unit2) |
+| 3 | Git | The basics of git and how to use GitHub. | [Unit 3](https://fellowship.icssc.club/docs/unit3) |
+| 4 | HTML, CSS, JavaScript | Intro to web development. | [Unit 4](https://fellowship.icssc.club/docs/unit4) |
+| 5 | Resume Review, LinkedIn | Improve personal branding and get yourself ready for internship applications. | [Unit 5](https://fellowship.icssc.club/docs/unit5) |
+| 6 | React | Develop a website using one of the most popular JavaScript libraries. | [Unit 6](https://fellowship.icssc.club/docs/unit6) |
+| 7 | APIs, REST, GraphQL  | Learn about how to fetch information from APIs | [Unit 7](https://fellowship.icssc.club/docs/unit7) |
+| 8 | TypeScript | Explore the programming language many web developers switched to. | [Unit 8](https://fellowship.icssc.club/docs/unit8) |
+| 9 | Collaboration on GitHub | Forking, branches, pull requests, and working as a team on GitHub. |  |
+| 10 | Open Source Contribution | Use the knowledge that you’ve learned this quarter to make a contribution to one our our ICSSC projects! | [Unit 10](https://fellowship.icssc.club/docs/unit10) |
+
+## <u>Course Content</u>
+
+Every Monday, the unit for the week will be released on Notion. Each unit will contain a pre-recorded video, external resources, and your assignment(s) for the week. You can look through this material at your own pace at a time that is convenient for your schedule. 
+
+We recommend reviewing the material as soon as possible though, so you can ask questions in Discord and/or Office Hours during the week.
+
+### Assignments
+
+Assignments are **due Monday at 11:59pm.**
+
+Each assignment will have a list of required tasks and a list of optional stretch goals for you to complete. You will receive a point for each task that you complete.
+
+### Passing the Course
+
+In order to pass the course, **you must complete all of the required tasks on all of the assignments**. 
+
+### Points Scoreboard
+
+Every point that you earn during the course will be added to your overall score. At the end of the quarter, the top performing students will receive a small prize (TBA 😉)
+
+### Late Policy
+
+For each day that an assignment is late, you will lose 25% of the points on that assignment.
+
+> *Example:* if you turn in an assignment 1 day late that had 4 tasks, you will lose 25% (1 point) and only receive 3 points.
+
+Since every unit builds on top of the previous one, it is important that you complete each assignment on-time.
+
+## <u>Course Communication</u>
+
+### Discord - *Our Messaging Platform*
+
+All communication will happen in the [ICSSC Projects Discord](http://discord.gg/GzF76D7UhY). 
+It is important that you check Discord regularly, so you don’t miss any important updates.
+After joining the server, we will give you a `fellow` role, which grants you access to the following channels in our Fellowship Category.
+
+| Channel | Description |
+| :--- | :--- |
+| #announcements | Important updates about the Fellowship. |
+| #fellowship | The main chat for you to meet others in the Fellowship. |
+| #questions | Any questions about technical problems, course logistics, or life. |
+| #voice-chat-text | For random messages from people in the voice channels. |
+| 🔈 Office Hours | Voice channel for our weekly office hours. |
+| 🔈 Work Session | Voice channel for you to use  |
+
+### Notion - *Our Canvas*
+
+All information about the Fellowship can be found on Notion. 
+
+Upon admission to the Fellowship, you will receive a link to our Notion dashboard. This dashboard is like our course’s Canvas and will be your primary resource hub during the quarter. 
+
+## <u>Office Hours</u>
+
+Chase and Raman will host Office Hours on Discord each week. You are welcome to come join the voice channel to ask any questions about the Fellowship assignments, career advice, or life in general! These are optional but we hope you’ll stop by to come hangout 😊
+
+***Location***: Discord `🔈 Office Hours` Voice Channel  
+***Day & Time:*** Tuesdays and Thursdays from 2-3pm


### PR DESCRIPTION
## Summary
Migrated Syllabus Notion page to new fellowship website
![localhost_3000_course_syllabus](https://user-images.githubusercontent.com/97374402/159139806-d8e65db9-3fed-47cf-9cc8-abf41d15837c.png)


## Test Plan
- Verified that the changes showed up in the new website's Syllabus page preview

## Issues
Closes #9 