### PR TITLE
Fixing Redirect unable to build

### DIFF
--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -1,19 +1,27 @@
 import React from 'react';
 import NotFound from '@theme-original/NotFound';
-import redirects from '@site/static/redirects.json'
+import redirects from '@site/static/redirects.json';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 
 export default function NotFoundWrapper(props) {
-  // Get the pathname and remove the leading /
-  // E.g. "/discord" -> "discord"
-  const pathname = window.location.pathname.substring(1);
+  return (
+    <BrowserOnly fallback={<NotFound {...props}/>}>
+      {() => {
+        // Get the pathname and remove the leading /
+        // E.g. "/discord" -> "discord"
+        const pathname = window.location.pathname.substring(1);
 
-  // If the path name is in the list of redirects,
-  // redirect to that location and return an empty component
-  if (pathname in redirects) {
-    window.location.replace(redirects[pathname])
-    return <></>
-  }
+        // If the path name is in the list of redirects,
+        // redirect to that location and return an empty component
+        if (pathname in redirects) {
+          window.location.replace(redirects[pathname])
+          return <></>
+        }
 
-  // Otherwise, return the origin 404 page
-  return <NotFound {...props} />
-}
+        // Otherwise, return the origin 404 page
+        return <NotFound {...props} />
+    }}
+    </BrowserOnly>
+  );
+};
+  


### PR DESCRIPTION
When running `npm run build`, it would break since we are using `window` variable. More on this here: https://docusaurus.io/docs/advanced/ssg

Added support for 'window' variable using BrowserOnly, so it will only render in the client-side render and not the server-side render. 

There is another issue with redirects, since `/apply` is considered a broken link. Not sure if it is at all possible to only ignore this case, or we must ignore all of them in the config. 

## Test Plan
Retry the redirect links. 
Run `npm run build` to test the build.

## Future Followup
I've added a test for building for github workflows in e8e37b6d7c7c7c9ca7e60e64f2ce7da446f6f18e, so this doesn't have to be checked manually.