### PR TITLE
Added new tagline and fixed typos in homepage

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'ICSSC Fellowship',
-  tagline: 'A crash course on web development.',
+  tagline: 'A crash course on web development. 💻',
   url: 'https://fellowship.icssc.club',
   baseUrl: '/',
   onBrokenLinks: 'warn',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'ICSSC Fellowship',
-  tagline: '🚧 This site is currently under construction 🚧',
+  tagline: 'A crash course on web development.',
   url: 'https://fellowship.icssc.club',
   baseUrl: '/',
   onBrokenLinks: 'warn',

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -7,13 +7,13 @@ const FeatureList = [
     title: 'Learn Foundational Skills',
     description: (
       <>
-        Learn foundational software development skills like how to use Git, Github, the Terminal.
+        Learn foundational software development skills like how to use Git, Github, and the Terminal.
         We'll also cover professional development topics like Resumes, LinkedIn, and Interview Prep.
       </>
     ),
   },
   {
-    title: 'Learn Web Development',
+    title: 'Develop Websites',
     description: (
       <>
         Starting with HTML, CSS, and Javascript, we'll learn how to create simple websites.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,6 +12,7 @@ function HomepageHeader() {
     <header className={clsx('hero', styles.heroBanner)}>
       <div className="container">
         <h1 className="hero__title">{siteConfig.title}</h1>
+        <p className="hero__subtitle">Learn. Develop. Contribute.</p>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
           <Link
@@ -32,7 +33,7 @@ export default function Home() {
   return (
     <Layout
       title={siteConfig.title}
-      description="Description will go into a meta tag in <head />">
+      description={siteConfig.tagline}>
       <HomepageHeader />
       <main>
         <HomepageFeatures />

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -21,3 +21,7 @@
   align-items: center;
   justify-content: center;
 }
+
+p {
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
Changed our tagline to `A crash course on web development`. Also added `Learn. Develop. Contribute.` above to match our feature list. 

Thoughts on whether to add an emoji? It's not there right now, but this is what it looks like:
![image](https://user-images.githubusercontent.com/9029237/160488874-c0f56fa9-39f1-46fc-9eb8-22f7b74bbebd.png)
![image](https://user-images.githubusercontent.com/9029237/160488948-6117820d-ce31-4fc4-a37d-b969ba92f3b0.png)
It looks fine on dark mode too: 
![image](https://user-images.githubusercontent.com/9029237/160489106-043e7b57-6186-493e-ab43-5f155536c0d1.png)


## Test Plan
Check the homepage locally to see that the changes are there. 