### PR TITLE
Set default mode to the dark theme

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,6 +67,9 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
+      colorMode: {
+        defaultMode: 'dark'
+      }
     }),
 };
 


### PR DESCRIPTION
Since the dark theme is currently more accessible than the light theme, should we make this the default?

Note: to test this change you have to `npm run build` and `npm run serve`